### PR TITLE
Make the sticky aside menu work with a top value

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -117,7 +117,7 @@ function NavigationDesktop() {
   const pathname = usePathname();
 
   return (
-    <aside className='sticky hidden h-[calc(100dvh-theme(spacing.16))] w-[220px] shrink-0 pt-8 md:block lg:pt-12'>
+    <aside className='sticky top-14 hidden h-[calc(100dvh-theme(spacing.16))] w-[220px] shrink-0 pt-8 md:block lg:pt-12'>
       <ScrollArea>
         <nav>
           <ul role='list' className='h-full'>


### PR DESCRIPTION
I just noticed that the navigation menu is not working with `position: sticky`, so I just added the `top-14` class to fix it.