### PR TITLE
docs: fix the npm installation command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ git checkout -b my-new-branch
 ### Install dependencies
 
 ```bash
-pnpm install
+npm install
 ```
 
 ## Commit Convention


### PR DESCRIPTION
As we are using npm as package manager, fixed the typo in the installation command