### PR TITLE
fix(button): remove the svg fill for the arrow icon

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -98,7 +98,7 @@ export default function Motion() {
             <Link href='/docs'>
               <Button>
                 Explore Docs
-                <ChevronRight className='ml-1.5 h-4 w-4 fill-white dark:fill-zinc-950' />
+                <ChevronRight className='ml-1.5 h-4 w-4' />
               </Button>
             </Link>
             <a


### PR DESCRIPTION
Removing the `fill` from the svg arrow since it uses only a `stroke` line, it bothers me every time I see it 😄