### PR TITLE
fix sidebar scroll

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -128,7 +128,7 @@ function NavigationDesktop() {
 
   return (
     <aside className='sticky top-14 hidden h-[calc(100dvh-theme(spacing.16))] w-[220px] shrink-0 pt-8 md:block lg:pt-12'>
-      <ScrollArea>
+      <ScrollArea className='h-full w-full'>
         <nav>
           <ul role='list' className='h-full'>
             {NAVIGATION.map((item, index) => {


### PR DESCRIPTION
## Description:
This PR addresses a bug (#34 ) in the sidebar component where scrolling was not functioning as expected. The issue prevented users from being able to scroll through the sidebar content when it overflowed the viewport, leading to a poor user experience, especially on smaller screens.

## Issue:
- Sidebar scroll was not working, causing content to be inaccessible when the sidebar's height exceeded the viewport height.

## fix:
- The issue was resolved by defining the height on the `ScrollArea` component in the `docs/layout`.