### PR TITLE
feat(components): add new optional duration prop to texteffect component

### DIFF
--- a/components/core/text-effect.tsx
+++ b/components/core/text-effect.tsx
@@ -24,6 +24,7 @@ type TextEffectProps = {
   trigger?: boolean;
   onAnimationComplete?: () => void;
   segmentWrapperClassName?: string;
+  duration?: number;
 };
 
 const defaultStaggerTimes: Record<'char' | 'word' | 'line', number> = {
@@ -159,6 +160,7 @@ export function TextEffect({
   trigger = true,
   onAnimationComplete,
   segmentWrapperClassName,
+  duration = 1,
 }: TextEffectProps) {
   let segments: string[];
 
@@ -178,7 +180,7 @@ export function TextEffect({
   const itemVariants = variants?.item || selectedVariants.item;
   const ariaLabel = per === 'line' ? undefined : children;
 
-  const stagger = defaultStaggerTimes[per];
+  const stagger = defaultStaggerTimes[per] * duration;
 
   const delayedContainerVariants: Variants = {
     hidden: containerVariants.hidden,
@@ -188,8 +190,11 @@ export function TextEffect({
         ...(containerVariants.visible as TargetAndTransition)?.transition,
         staggerChildren:
           (containerVariants.visible as TargetAndTransition)?.transition
-            ?.staggerChildren || stagger,
-        delayChildren: delay,
+            ?.staggerChildren
+            ? (containerVariants.visible as TargetAndTransition).transition!
+                .staggerChildren! * duration
+            : stagger,
+        delayChildren: delay * duration,
       },
     },
     exit: containerVariants.exit,


### PR DESCRIPTION
feat(components): add new optional duration prop to texteffect component

- Introduced a new `duration` prop to the `TextEffect` component.
- Allows customization of animation speed by scaling stagger and delay timings.
- Default value is set to `1`, preserving existing behavior when the prop is not provided.
- Example usage: duration={2} // Slows down the animation to twice the default speed

resolves #65