### PR TITLE
motion() is deprecated. Use motion.create() instead.

### DIFF
--- a/components/core/text-shimmer.tsx
+++ b/components/core/text-shimmer.tsx
@@ -18,7 +18,7 @@ export function TextShimmer({
   duration = 2,
   spread = 2,
 }: TextShimmerProps) {
-  const MotionComponent = motion(Component as keyof JSX.IntrinsicElements);
+  const MotionComponent = motion.create(Component as keyof JSX.IntrinsicElements);
 
   const dynamicSpread = useMemo(() => {
     return children.length * spread;


### PR DESCRIPTION
Self explanatory