### PR TITLE
fix: Edit TextMorph Component to Handle Spaces Explicitly

### DIFF
--- a/components/core/text-morph.tsx
+++ b/components/core/text-morph.tsx
@@ -27,7 +27,12 @@ export function TextMorph({
 
       return {
         id: `${uniqueId}-${lowerChar}${charCounts[lowerChar]}`,
-        label: index === 0 ? char.toUpperCase() : lowerChar,
+        label:
+          char === ' '
+            ? '\u00A0'
+            : index === 0
+              ? char.toUpperCase()
+              : lowerChar, // Handle spaces explicitly
       };
     });
   }, [children, uniqueId]);


### PR DESCRIPTION
#### Description:

This PR addresses the issue of spaces being collapsed or ignored in the `TextMorph` component. The changes ensure that spaces are handled explicitly, allowing text with spaces to be displayed correctly. The original functionality of the `TextMorph` component is maintained.

#### Changes:

**TextMorph Component**:
   - Modified the `TextMorph` component to replace spaces with a non-breaking space (`\u00A0`).
   - This ensures that spaces are displayed correctly in the rendered text.