### PR TITLE
Fixed Dock Component using ReactElement

### DIFF
--- a/components/core/dock.tsx
+++ b/components/core/dock.tsx
@@ -20,6 +20,7 @@ import {
   useState,
 } from 'react';
 import { cn } from '@/lib/utils';
+import React from 'react';
 
 const DOCK_HEIGHT = 128;
 const DEFAULT_MAGNIFICATION = 80;
@@ -108,7 +109,7 @@ function Dock({
           mouseX.set(Infinity);
         }}
         className={cn(
-          'mx-auto flex w-fit gap-4 rounded-2xl bg-gray-50 px-4 dark:bg-neutral-900',
+          'mx-auto flex w-fit gap-4 rounded-2xl bg-black px-4 dark:bg-neutral-900',
           className
         )}
         style={{ height: panelHeight }}
@@ -160,11 +161,18 @@ function DockItem({ children, className }: DockItemProps) {
       aria-haspopup='true'
     >
       {Children.map(children, (child) =>
-        cloneElement(child as React.ReactElement, { width, isHovered })
+        React.isValidElement(child)
+          ? cloneElement(child as React.ReactElement<{ width: MotionValue<number>; isHovered: MotionValue<number> }>, {
+              width,
+              isHovered,
+            })
+          : child
       )}
     </motion.div>
   );
 }
+
+
 
 function DockLabel({ children, className, ...rest }: DockLabelProps) {
   const restProps = rest as Record<string, unknown>;
@@ -188,7 +196,7 @@ function DockLabel({ children, className, ...rest }: DockLabelProps) {
           exit={{ opacity: 0, y: 0 }}
           transition={{ duration: 0.2 }}
           className={cn(
-            'absolute -top-6 left-1/2 w-fit whitespace-pre rounded-md border border-gray-200 bg-gray-100 px-2 py-0.5 text-xs text-neutral-700 dark:border-neutral-900 dark:bg-neutral-800 dark:text-white',
+            'absolute -top-6 left-1/2 w-fit whitespace-pre rounded-md px-2 py-0.5 text-sm text-white dark:border-neutral-900 dark:bg-neutral-800 dark:text-white',
             className
           )}
           role='tooltip'

--- a/components/core/dock.tsx
+++ b/components/core/dock.tsx
@@ -18,9 +18,9 @@ import {
   useMemo,
   useRef,
   useState,
+  React
 } from 'react';
 import { cn } from '@/lib/utils';
-import React from 'react';
 
 const DOCK_HEIGHT = 128;
 const DEFAULT_MAGNIFICATION = 80;
@@ -109,7 +109,7 @@ function Dock({
           mouseX.set(Infinity);
         }}
         className={cn(
-          'mx-auto flex w-fit gap-4 rounded-2xl bg-black px-4 dark:bg-neutral-900',
+          'mx-auto flex w-fit gap-4 rounded-2xl bg-gray-50 px-4 dark:bg-neutral-900',
           className
         )}
         style={{ height: panelHeight }}
@@ -172,8 +172,6 @@ function DockItem({ children, className }: DockItemProps) {
   );
 }
 
-
-
 function DockLabel({ children, className, ...rest }: DockLabelProps) {
   const restProps = rest as Record<string, unknown>;
   const isHovered = restProps['isHovered'] as MotionValue<number>;
@@ -196,7 +194,7 @@ function DockLabel({ children, className, ...rest }: DockLabelProps) {
           exit={{ opacity: 0, y: 0 }}
           transition={{ duration: 0.2 }}
           className={cn(
-            'absolute -top-6 left-1/2 w-fit whitespace-pre rounded-md px-2 py-0.5 text-sm text-white dark:border-neutral-900 dark:bg-neutral-800 dark:text-white',
+            'absolute -top-6 left-1/2 w-fit whitespace-pre rounded-md border border-gray-200 bg-gray-100 px-2 py-0.5 text-xs text-neutral-700 dark:border-neutral-900 dark:bg-neutral-800 dark:text-white',
             className
           )}
           role='tooltip'


### PR DESCRIPTION
What the old code did

```
{Children.map(children, (child) =>
  cloneElement(child as React.ReactElement, { width, isHovered })
)}
```

Directly casts `child `as a `React.ReactElement`:
The code assumes every `child ` is a valid React element and can accept the `width `and `isHovered `props.

No runtime validation:
If a `child` is not a valid React element or does not support `width` or `isHovered`, it could result in runtime errors.

TypeScript warnings:
TypeScript flags the call to `cloneElement `because it doesn't know whether `width `or `isHovered `are valid props for the given `child`. This weakens type safety.

**What the updated code does**

```
{Children.map(children, (child) =>
  React.isValidElement(child)
    ? cloneElement(
        child as React.ReactElement<{ width: MotionValue<number>; isHovered: MotionValue<number> }>, 
        { width, isHovered }
      )
    : child
)}
```

**Validates the child at runtime:**

Uses `React.isValidElement(child)` to check if the child is a valid React element before attempting to clone it.
If the child is not a React element (e.g., a string or number), it bypasses cloning and returns the child as-is, preventing runtime errors.

**Explicitly defines the expected props for cloning:**

- Casts child as a `React.ReactElement<{ width: MotionValue<number>; isHovered: MotionValue<number> }>`.
- This tells TypeScript that the child must support `width `and `isHovered `props.
- Resolves the TypeScript error by aligning the `cloneElement `props with the child’s expected type.

**Improves robustness and maintainability:**

- Prevents accidental runtime errors by ensuring only valid React elements are cloned.
- Makes the function self-documenting—future contributors can clearly see that width and isHovered are being passed to valid React elements.