### PR TITLE
fix: better typescript support for text effect variant

### DIFF
--- a/components/core/text-effect.tsx
+++ b/components/core/text-effect.tsx
@@ -2,12 +2,14 @@
 import { cn } from '@/lib/utils';
 import {
   AnimatePresence,
-  motion,
+  motion
+} from 'motion/react';
+import type {
   TargetAndTransition,
   Transition,
   Variant,
   Variants,
-} from 'motion/react';
+} from 'motion/react'
 import React from 'react';
 
 export type PresetType = 'blur' | 'fade-in-blur' | 'scale' | 'fade' | 'slide';
@@ -164,10 +166,11 @@ const splitText = (text: string, per: 'line' | 'word' | 'char') => {
 };
 
 const hasTransition = (
-  variant: Variant
+  variant?: Variant
 ): variant is TargetAndTransition & { transition?: Transition } => {
+  if (!variant) return false;
   return (
-    typeof variant === 'object' && variant !== null && 'transition' in variant
+    typeof variant === 'object' && 'transition' in variant
   );
 };
 


### PR DESCRIPTION
Add better typescript support for instances where `baseVariants.visible` may be undefined

<img width="701" alt="Screenshot 2025-03-10 at 00 57 08" src="https://github.com/user-attachments/assets/8c52209b-6a99-413e-a1dd-9716c2e99920" />
