### PR TITLE
[Spotlight] Improve contrast on light theme

### DIFF
--- a/components/core/spotlight.tsx
+++ b/components/core/spotlight.tsx
@@ -70,7 +70,7 @@ export function Spotlight({
       ref={containerRef}
       className={cn(
         'pointer-events-none absolute rounded-full bg-[radial-gradient(circle_at_center,var(--tw-gradient-stops),transparent_80%)] blur-xl transition-opacity duration-200',
-        'from-zinc-50 via-zinc-100 to-zinc-200',
+        'from-zinc-100 via-zinc-200 to-zinc-400 dark:from-zinc-50 dark:via-zinc-100 dark:to-zinc-200',
         isHovered ? 'opacity-100' : 'opacity-0',
         className
       )}


### PR DESCRIPTION
Fixes #141 

The example is not broken. However, the effect on is hardly visible on light mode. I made a small tweak so to improve the contrast.

Please let me know if any more adjustments are desired!