### PR TITLE
feat(DockItem): add optional onClick support

### DIFF
--- a/app/docs/dock/page.mdx
+++ b/app/docs/dock/page.mdx
@@ -67,10 +67,11 @@ A versatile UI element that provides a flexible and customizable way to organize
 
 ### DockItem
 
-| Prop      | Type      | Default   | Description                                   |
-| :-------- | :-------- | :-------- | :-------------------------------------------- |
-| children  | ReactNode |           | DockLabel and DockIcon                        |
-| className | string    | undefined | Optional CSS class for styling the component. |
+| Prop      | Type       | Default   | Description                                                |
+| :-------- | :--------- | :-------- | :--------------------------------------------------------- |
+| children  | ReactNode  |           | DockLabel and DockIcon                                     |
+| className | string     | undefined | Optional CSS class for styling the component.              |
+| onClick   | () => void | undefined | Optional click handler triggered when the item is clicked. |
 
 ### DockLabel
 

--- a/components/core/dock.tsx
+++ b/components/core/dock.tsx
@@ -38,6 +38,7 @@ export type DockProps = {
 export type DockItemProps = {
   className?: string;
   children: React.ReactNode;
+  onClick?: () => void;
 };
 
 export type DockLabelProps = {
@@ -127,7 +128,7 @@ function Dock({
   );
 }
 
-function DockItem({ children, className }: DockItemProps) {
+function DockItem({ children, className, onClick }: DockItemProps) {
   const ref = useRef<HTMLDivElement>(null);
 
   const { distance, magnification, mouseX, spring } = useDock();
@@ -162,6 +163,7 @@ function DockItem({ children, className }: DockItemProps) {
       tabIndex={0}
       role='button'
       aria-haspopup='true'
+      onClick={onClick}
     >
       {Children.map(children, (child) =>
         cloneElement(child as React.ReactElement, { width, isHovered })


### PR DESCRIPTION
- This PR adds support for an optional `onClick` prop to the `DockItem` component.

- Also Updated the `page.mdx`

Please let me know if there's anything I can improve or have missed, this is my <ins>first ever contribution</ins> and I am not sure if I am doing it right.
