### PR TITLE
fix(registry): missing `react-use-measure` dependency

### DIFF
--- a/public/c/infinite-slider.json
+++ b/public/c/infinite-slider.json
@@ -3,7 +3,8 @@
   "type": "registry:ui",
   "registryDependencies": [],
   "dependencies": [
-    "motion"
+    "motion",
+    "react-use-measure"
   ],
   "devDependencies": [],
   "tailwind": {},

--- a/public/c/registry.json
+++ b/public/c/registry.json
@@ -223,7 +223,8 @@
       "title": "Infinite Slider",
       "description": "A slider component that loops infinitely through its content.",
       "dependencies": [
-        "motion"
+        "motion",
+        "react-use-measure"
       ],
       "devDependencies": [],
       "registryDependencies": [],
@@ -571,7 +572,8 @@
       "title": "Toolbar Expandable",
       "description": "An expandable toolbar that reveals additional options with animations.",
       "dependencies": [
-        "motion"
+        "motion",
+        "react-use-measure"
       ],
       "devDependencies": [],
       "registryDependencies": [],
@@ -638,7 +640,8 @@
       "title": "Sliding Number",
       "description": "A component that transitions between numbers with a sliding animation.",
       "dependencies": [
-        "motion"
+        "motion",
+        "react-use-measure"
       ],
       "devDependencies": [],
       "registryDependencies": [],

--- a/public/c/sliding-number.json
+++ b/public/c/sliding-number.json
@@ -3,7 +3,8 @@
   "type": "registry:ui",
   "registryDependencies": [],
   "dependencies": [
-    "motion"
+    "motion",
+    "react-use-measure"
   ],
   "devDependencies": [],
   "tailwind": {},

--- a/public/c/toolbar-expandable.json
+++ b/public/c/toolbar-expandable.json
@@ -3,7 +3,8 @@
   "type": "registry:ui",
   "registryDependencies": [],
   "dependencies": [
-    "motion"
+    "motion",
+    "react-use-measure"
   ],
   "devDependencies": [],
   "tailwind": {},

--- a/scripts/registry-components.ts
+++ b/scripts/registry-components.ts
@@ -113,7 +113,7 @@ export const components: ComponentDefinition[] = [
     name: 'infinite-slider',
     path: path.join(__dirname, '../components/core/infinite-slider.tsx'),
     registryDependencies: [],
-    dependencies: ['motion'],
+    dependencies: ['motion', 'react-use-measure'],
     description:
       'A slider component that loops infinitely through its content.',
   },
@@ -258,7 +258,7 @@ export const components: ComponentDefinition[] = [
     name: 'toolbar-expandable',
     path: path.join(__dirname, '../components/core/toolbar-expandable.tsx'),
     registryDependencies: [],
-    dependencies: ['motion'],
+    dependencies: ['motion', 'react-use-measure'],
     description:
       'An expandable toolbar that reveals additional options with animations.',
     files: [
@@ -289,7 +289,7 @@ export const components: ComponentDefinition[] = [
     name: 'sliding-number',
     path: path.join(__dirname, '../components/core/sliding-number.tsx'),
     registryDependencies: [],
-    dependencies: ['motion'],
+    dependencies: ['motion', 'react-use-measure'],
     description:
       'A component that transitions between numbers with a sliding animation.',
   },


### PR DESCRIPTION
### Affected components:

- [sliding-number](https://motion-primitives.com/docs/sliding-number)
- [infinite-slider](https://motion-primitives.com/docs/infinite-slider)
- [toolbar-expandable](https://motion-primitives.com/docs/toolbar-expandable)

### Before

`react-use-measure` is not installed automatically when using the shadcn registry

<img width="971" alt="image" src="https://github.com/user-attachments/assets/12f902c4-ebea-469e-b138-bd0882376ac7" />

### After

`react-use-measure` is installed automatically when using the shadcn registry

<img width="420" alt="image" src="https://github.com/user-attachments/assets/5573c3c1-dfb6-41a9-bbff-d4c19b2c2f70" />
