### PR TITLE
Fix sliding number TRANSITION type issue with 'as const' assertion

### DIFF
--- a/components/core/sliding-number.tsx
+++ b/components/core/sliding-number.tsx
@@ -10,7 +10,7 @@ import {
 import useMeasure from 'react-use-measure';
 
 const TRANSITION = {
-  type: 'spring',
+  type: 'spring' as const,
   stiffness: 280,
   damping: 18,
   mass: 0.3,


### PR DESCRIPTION
Fixes #159: TypeScript error where motion.span transition prop expects AnimationGeneratorType but was receiving generic string type.

- Added 'as const' to TRANSITION.type to ensure literal type inference
- Changed type: 'spring' to type: 'spring' as const
- Resolves TypeScript compatibility with motion component requirements