### PR TITLE
fix: accessibility relationships in MorphingDialog

### DIFF
--- a/components/core/morphing-dialog.tsx
+++ b/components/core/morphing-dialog.tsx
@@ -272,6 +272,7 @@ function MorphingDialogTitle({
 
   return (
     <motion.div
+      id={`motion-ui-morphing-dialog-title-${uniqueId}`}
       layoutId={`dialog-title-container-${uniqueId}`}
       className={className}
       style={style}
@@ -327,7 +328,7 @@ function MorphingDialogDescription({
 
   return (
     <motion.div
-      key={`dialog-description-${uniqueId}`}
+      id={`motion-ui-morphing-dialog-description-${uniqueId}`}
       layoutId={
         disableLayoutAnimation
           ? undefined
@@ -338,7 +339,6 @@ function MorphingDialogDescription({
       initial='initial'
       animate='animate'
       exit='exit'
-      id={`dialog-description-${uniqueId}`}
     >
       {children}
     </motion.div>


### PR DESCRIPTION
## Description

This PR fixes broken accessibility references in the MorphingDialog component. The aria-labelledby and aria-describedby attributes on the main dialog container were referencing IDs that either did not exist or did not match the child components.

## Related Issue

Closes https://github.com/ibelick/motion-primitives/issues/168

## Changes

- MorphingDialogTitle: Added the missing id attribute (motion-ui-morphing-dialog-title-${uniqueId}).
- MorphingDialogDescription: 
     - Updated the id to match the expected format (motion-ui-morphing-dialog-description-${uniqueId}).
     - Removed an unnecessary key prop.

## Impact

- Assistive technologies will now correctly associate the dialog with its title and description, ensuring compliant accessibility behavior.